### PR TITLE
Handle path with spaces

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -427,7 +427,12 @@ int main(int argc, char* argv[]) {
 #endif
         } else if (id == "#") {
             std::string str;
-            std::cin >> str;
+            char add = ' ';
+            while(add != 0)
+            {
+                std::cin.get(add);
+                str.append(1, add);
+            }
             id = str;
         }
         juce::initialiseJuce_GUI();


### PR DESCRIPTION
Fix a bug where plugin path with spaces (e.g. plugins in `C:\Program Files\VST3`) cannot be retrieved correctly.